### PR TITLE
Slightly robustified installer that passes adb flags; added update, delete scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,26 @@
-Gets the latest Chrome on Android Test Shell and installs it on all running emulators and connected devices.
+# Install
+Get the latest Chrome on Android Test Shell and installs it on all running emulators and connected devices
 
-`./install-chromeandroid.sh`
+`./install-chromeandroid.sh [-slr]`
 
+which accepts the following familiar command line flags:
+
+- `-s` installs on SD card instead of internal storage
+- `-l` forward-locks the app
+- `-r` reinstalls the app, keeping its data
+
+# Update Existing
+
+`./update-chromeandroid.sh [-slr]`
+
+Same as above and accepts the same flags, but first uninstalls — while preserving data and cache directories — the existing package from the device.
+
+# Deleting
+Just for the sake of completness, we include
+`./delete-chromeandroid.sh`
+which accepts the optional `-k` commandline flag to keep data and cache directories (which you probably never want to do unless you're updating, which is provided for above).
+
+# Automation
+These scripts should be suitable for inclusion in other automated workflows: each requirement is validated and the script will terminate immediately with exit code 1 if something bad happens (curl fails, unzip fails, uninstall while updating fails, etc).
+
+Find a few [more details here](http://paul.kinlan.me/installing-chrome-for-android-on-an-emulator/)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Install
-Get the latest Chrome on Android Test Shell and installs it on all running emulators and connected devices
+Get the latest Chrome on Android Test Shell and install it on all running emulators and connected devices with
 
 `./install-chromeandroid.sh [-slr]`
 

--- a/delete-chromeandroid.sh
+++ b/delete-chromeandroid.sh
@@ -1,0 +1,22 @@
+#! /bin/sh
+
+if [ $# -lt 1 ]
+then
+		echo "Uninstalling org.chromium.chrome.testshell, wiping data and cache directories" >&2
+        adb uninstall org.chromium.chrome.testshell|| { echo "Uninstall failed"; exit 1; }
+        exit
+fi
+
+while getopts "k" opt; do
+	case $opt in
+		k)
+			echo "Uninstalling org.chromium.chrome.testshell, keeping data and cache directories" >&2
+			adb shell pm uninstall -k org.chromium.chrome.testshell || { echo "Uninstall failed"; exit 1; }
+			;;
+		*)
+			echo "Usage: $0 [-k]" >&2
+			exit 1
+			;;
+	esac
+done
+

--- a/install-chromeandroid.sh
+++ b/install-chromeandroid.sh
@@ -2,13 +2,42 @@
 
 LATEST=`curl -s http://commondatastorage.googleapis.com/chromium-browser-continuous/Android/LAST_CHANGE`
 
-echo Latest Chromium Android at $LATEST
+echo "Latest Chromium Android at $LATEST\n"
 
-TMP_DL=`mktemp -t chrome-android.XXXX`
-TMP_APK=`mktemp -t chrome-android.XXXX`
+TMP_DL=`mktemp -t chrome-android.XXXX`   || { echo "FATAL: Could not create temp file"; exit 1; }
+TMP_APK=`mktemp -t chrome-android.XXXX`  || { echo "FATAL: Could not create temp file"; exit 1; }
 REMOTE_APK=http://commondatastorage.googleapis.com/chromium-browser-continuous/Android/$LATEST/chrome-android.zip
-echo Downlaoding $REMOTE_APK to $TMP_DL
-curl $REMOTE_APK -o $TMP_DL
-echo Extracting ChromiumTestShell.apk to $TMP_APK
-unzip -p $TMP_DL chrome-android/apks/ChromiumTestShell.apk >> $TMP_APK
-adb install $TMP_APK
+
+echo "Downlaoding \n\t$REMOTE_APK \n\tto $TMP_DL\n"
+curl $REMOTE_APK -o $TMP_DL  || { echo "FATAL: downloading $TMP_APK failed"; exit 1; }
+
+echo "Extracting ChromiumTestShell.apk \n\t to $TMP_APK\n"
+unzip -p $TMP_DL chrome-android/apks/ChromiumTestShell.apk >> $TMP_APK || { echo "FATAL: extracting $TMP_APK failed"; exit 1; }
+
+echo "Installing APK"
+
+##
+# Install flags
+# '-l' means forward-lock the app
+# '-r' means reinstall the app, keeping its data
+# '-s' means install on SD card instead of internal storage
+##
+
+while getopts "rsl" opt; do
+	case $opt in
+		l)
+			echo "- with forward-lock" >&2
+			;;
+		r)
+			echo "- reinstalling, keeping data" >&2
+			;;
+		s)
+			echo "- on SD card \n" >&2
+			;;
+		\?)
+			echo "Invalid option: -$OPTARG" >&2
+			;;
+	esac
+done
+
+adb install $@ $TMP_APK || { echo "FATAL: adb install failed"; exit 1; }

--- a/update-chromeandroid.sh
+++ b/update-chromeandroid.sh
@@ -1,0 +1,43 @@
+#! /bin/sh
+
+LATEST=`curl -s http://commondatastorage.googleapis.com/chromium-browser-continuous/Android/LAST_CHANGE`
+
+echo "Latest Chromium Android at $LATEST\n"
+
+TMP_DL=`mktemp -t chrome-android.XXXX`   || { echo "FATAL: Could not create temp file"; exit 1; }
+TMP_APK=`mktemp -t chrome-android.XXXX`  || { echo "FATAL: Could not create temp file"; exit 1; }
+REMOTE_APK=http://commondatastorage.googleapis.com/chromium-browser-continuous/Android/$LATEST/chrome-android.zip
+
+echo "Downlaoding \n\t$REMOTE_APK \n\tto $TMP_DL\n"
+curl $REMOTE_APK -o $TMP_DL  || { echo "FATAL: downloading $TMP_APK failed"; exit 1; }
+
+echo "Extracting ChromiumTestShell.apk \n\t to $TMP_APK\n"
+unzip -p $TMP_DL chrome-android/apks/ChromiumTestShell.apk >> $TMP_APK  || { echo "FATAL: extracting $TMP_APK failed"; exit 1; }
+
+echo "Uninstalling previous org.chromium.chrome.testshell, keeping data and cache\n"
+adb shell pm uninstall -k org.chromium.chrome.testshell || { echo "FATAL: Uninstalling previous version failed"; exit 1; }
+
+echo "Installing APK"
+
+##
+# Install flags
+# '-l' means forward-lock the app
+# '-r' means reinstall the app, keeping its data
+# '-s' means install on SD card instead of internal storage
+##
+
+while getopts "rsl" opt; do
+	case $opt in
+		l)
+			echo "- with forward-lock" >&2
+			;;
+		r)
+			echo "- reinstalling, keeping data" >&2
+			;;
+		s)
+			echo "- on SD card \n" >&2
+			;;
+	esac
+done
+
+adb install $@ $TMP_APK || { echo "FATAL: adb install failed"; exit 1; }


### PR DESCRIPTION
I came across your awesome Chromium Test Shell installer this morning and made a few modifications for myself. Here you go, if you're interested!

Most notably, the script tracks requirements and aborts (`exit 1`) if they're unmet, like `curl` failing to download the package. This should make it slightly more reliable in automated, unattended or triggered workflows.

I also added a simple updater and deleter (the latter of which is totally unnecessary but what the heck…)

I've tested it out in the emulator and my physical Nexus 7: both seem to work fine.

:warning: I'm not entirely confident on the use of `adb shell pm uninstall -k org.chromium.chrome.testshell` on update (line 18) and delete (line 14), but `adb` complained when I tried `adb uninstall -k` by itself. Please do fix that if I've gotten it wrong.
