### PR TITLE
Update APK names from new LATEST package; add ContentShell.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Install
-Get the latest Chrome on Android Test Shell and install it on all running emulators and connected devices with
+Get the latest Chrome on Android ChromeShell and ContentShell and install it on all running emulators and connected devices with
 
 `./install-chromeandroid.sh [-slr]`
 

--- a/delete-chromeandroid.sh
+++ b/delete-chromeandroid.sh
@@ -1,17 +1,21 @@
 #! /bin/sh
 
+set -u
+
 if [ $# -lt 1 ]
 then
-		echo "Uninstalling org.chromium.chrome.testshell, wiping data and cache directories" >&2
-        adb uninstall org.chromium.chrome.testshell|| { echo "Uninstall failed"; exit 1; }
-        exit
+	echo "Uninstalling org.chromium.chrome.{shell,content_shell_apk} and wiping data and cache directories" >&2
+	adb shell pm uninstall -k org.chromium.chrome.shell      || { echo "FATAL: Uninstalling previous version failed"; exit 1; }
+	adb shell pm uninstall -k org.chromium.content_shell_apk || { echo "FATAL: Uninstalling previous version failed"; exit 1; }    
+	exit
 fi
 
 while getopts "k" opt; do
 	case $opt in
 		k)
 			echo "Uninstalling org.chromium.chrome.testshell, keeping data and cache directories" >&2
-			adb shell pm uninstall -k org.chromium.chrome.testshell || { echo "Uninstall failed"; exit 1; }
+			adb shell pm uninstall -k org.chromium.chrome.shell      || { echo "Uninstall failed"; exit 1; }
+			adb shell pm uninstall -k org.chromium.content_shell_apk || { echo "Uninstall failed"; exit 1; }
 			;;
 		*)
 			echo "Usage: $0 [-k]" >&2

--- a/install-chromeandroid.sh
+++ b/install-chromeandroid.sh
@@ -1,20 +1,24 @@
 #! /bin/sh
 
+set -u
+
 LATEST=`curl -s http://commondatastorage.googleapis.com/chromium-browser-continuous/Android/LAST_CHANGE`
 
-echo "Latest Chromium Android at $LATEST\n"
+echo "Latest Chromium/Content Shell for Android is $LATEST\n"
 
-TMP_DL=`mktemp -t chrome-android.XXXX`   || { echo "FATAL: Could not create temp file"; exit 1; }
-TMP_APK=`mktemp -t chrome-android.XXXX`  || { echo "FATAL: Could not create temp file"; exit 1; }
+TMP_DL=`mktemp -t chrome-android.XXXX`           || { echo "FATAL: Could not create temp file"; exit 1; }
+TMP_CHROME_APK=`mktemp -t chrome-android.XXXX`   || { echo "FATAL: Could not create temp file"; exit 1; }
+TMP_CONTENT_APK=`mktemp -t chrome-android.XXXX`  || { echo "FATAL: Could not create temp file"; exit 1; }
 REMOTE_APK=http://commondatastorage.googleapis.com/chromium-browser-continuous/Android/$LATEST/chrome-android.zip
 
 echo "Downlaoding \n\t$REMOTE_APK \n\tto $TMP_DL\n"
 curl $REMOTE_APK -o $TMP_DL  || { echo "FATAL: downloading $TMP_APK failed"; exit 1; }
 
-echo "Extracting ChromiumTestShell.apk \n\t to $TMP_APK\n"
-unzip -p $TMP_DL chrome-android/apks/ChromiumTestShell.apk >> $TMP_APK || { echo "FATAL: extracting $TMP_APK failed"; exit 1; }
+echo "Extracting ChromeShell.apk \n\t to $TMP_CHROME_APK...\n"
+unzip -p $TMP_DL chrome-android/apks/ChromeShell.apk >> $TMP_CHROME_APK || { echo "FATAL: extracting $TMP_APK failed"; exit 1; }
 
-echo "Installing APK"
+echo "Extracting ChromiumTestShell.apk \n\t to $TMP_CONTENT_APK...\n"
+unzip -p $TMP_DL chrome-android/apks/ContentShell.apk >> $TMP_CONTENT_APK || { echo "FATAL: extracting $TMP_APK failed"; exit 1; }
 
 ##
 # Install flags
@@ -40,4 +44,8 @@ while getopts "rsl" opt; do
 	esac
 done
 
-adb install $@ $TMP_APK || { echo "FATAL: adb install failed"; exit 1; }
+echo "Installing ContentShell..."
+adb install $@ $TMP_CONTENT_APK || { echo "FATAL: adb install failed"; exit 1; }
+
+echo "Installing ChromeShell..."
+adb install $@ $TMP_CHROME_APK  || { echo "FATAL: adb install failed"; exit 1; }


### PR DESCRIPTION
Though this may be somewhat redundant with the ninja workflow [described here](https://code.google.com/p/chromium/wiki/AndroidBuildInstructions#Disable_USB_debugging_on_your_Android_device), it's still a useful tool which was broken by the new `LATEST` chromium package.

This fixes #5.
